### PR TITLE
Skip commented app link variables

### DIFF
--- a/national/.env
+++ b/national/.env
@@ -28,4 +28,3 @@ DHIS2_DATA_ENTRY_RELEASE_URL=https://github.com/IntelliSOFT-Consulting/PSS-Insig
 DHIS2_CONFIGURATION_RELEASE_URL=https://github.com/IntelliSOFT-Consulting/PSS-Insight-v2-National-Dhis2App/archive/refs/tags/v1.0.0.zip
 DHIS2_DATA_IMPORT_RELEASE_URL=https://github.com/IntelliSOFT-Consulting/PSS-Insight-v2-Data-Import/archive/refs/tags/v1.0.0.zip
 DHIS2_INDICATOR_SYNC_RELEASE_URL=https://github.com/IntelliSOFT-Consulting/PSS-Insight-v2-Indicator-Sync-Dhis2App/archive/refs/tags/v1.0.0.zip
-

--- a/national/scripts/webapps.sh
+++ b/national/scripts/webapps.sh
@@ -99,6 +99,10 @@ data_import_app_release=""
 indicator_sync_app_release=""
 
 while IFS= read -r line; do
+    # skip comments
+    if [[ $line =~ ^# ]]; then
+        continue
+    fi
     if [[ $line =~ ^SOURCE_URL=(.*)$ ]]; then
         dhis2_url="${BASH_REMATCH[1]%/api/*}"
     elif [[ $line =~ ^SOURCE_USERNAME=(.*)$ ]]; then


### PR DESCRIPTION
- Updated the releases not to show the babel warnings
- Skip commented app links in .env